### PR TITLE
Fix upload test

### DIFF
--- a/spec/requests/graphql/mutations/upload_user_photo_spec.rb
+++ b/spec/requests/graphql/mutations/upload_user_photo_spec.rb
@@ -2,15 +2,17 @@ require 'rails_helper'
 
 RSpec.describe 'Upload User Photo', type: :request do
   describe '.resolve' do
-    # Running into issue passing file in the query. Upload works on Altair. 
+    before(:each) do
+      @user = create(:mock_user) 
+      @image = Rack::Test::UploadedFile.new(file_fixture('green-blue-pink.jpeg'), "mime/type")
+    end
+
     it 'happy path: uploads file and creates photo' do 
-      user = create(:mock_user) 
-      image = Rack::Test::UploadedFile.new(file_fixture('green-blue-pink.jpeg'), "mime/type")
       query = <<~GQL
                 mutation($image: Upload!) {
                   uploadUserPhoto(input: {
                         upload: $image
-                        userId: #{user.id}}) {
+                        userId: #{@user.id}}) {
                             userId
                             unsplashId
                             userUploaded
@@ -18,7 +20,7 @@ RSpec.describe 'Upload User Photo', type: :request do
                           }
                         } 
                  GQL
-      post '/graphql', params: { query: query, variables: { image: image } }
+      post '/graphql', params: { query: query, variables: { image: @image } }
       json = JSON.parse(response.body, symbolize_names: true)
       photo = json[:data][:uploadUserPhoto]
 
@@ -27,30 +29,51 @@ RSpec.describe 'Upload User Photo', type: :request do
       expect(photo).to have_key(:userUploaded) 
       expect(photo).to have_key(:url) 
       
-      expect(user.photos.first.upload).to be_a(ActiveStorage::Attached::One)
-      expect(photo[:userId].to_i).to eq(user.id)
+      expect(@user.photos.first.upload).to be_a(ActiveStorage::Attached::One)
+      expect(photo[:userId].to_i).to eq(@user.id)
       expect(photo[:unsplashId]).to eq(nil)
       expect(photo[:userUploaded]).to eq(true)
       expect(photo[:url]).to eq(nil)
     end 
 
-    xit 'sad path: uploads file and creates photo' do 
-      user = create(:mock_user) 
-      upload = File.absolute_path("green-blue-pink.jpeg")
-
+    it 'sad path: cannot upload photo without user id' do 
       query = <<~GQL
                 mutation($image: Upload!) {
                   uploadUserPhoto(input: {
-                        upload: $#{upload}
-                        userId: #{user.id}}) {
+                        upload: $image
+                        userId: "#{}"}) {
                             userId
                             unsplashId
                             userUploaded
                           }
                         } 
                  GQL
+
+      post '/graphql', params: { query: query, variables: { image: @image } }
+      json = JSON.parse(response.body, symbolize_names: true)
+      error = json[:errors][0][:message]
+      
+      expect(error).to eq("Argument 'userId' on InputObject 'UploadUserPhotoInput' has an invalid value (\"\"). Expected type 'Int!'.")
+    end
+
+    it 'sad path: cannot upload photo without image' do 
+      query = <<~GQL
+                mutation($image: Upload!) {
+                  uploadUserPhoto(input: {
+                        upload: $image
+                        userId: #{@user.id}}) {
+                            userId
+                            unsplashId
+                            userUploaded
+                          }
+                        } 
+                 GQL
+
       post '/graphql', params: { query: query }
       json = JSON.parse(response.body, symbolize_names: true)
-    end 
+      error = json[:errors][0][:message]
+      
+      expect(error).to eq("Variable $image of type Upload! was provided invalid value")
+    end
   end
 end

--- a/spec/requests/graphql/mutations/upload_user_photo_spec.rb
+++ b/spec/requests/graphql/mutations/upload_user_photo_spec.rb
@@ -3,22 +3,35 @@ require 'rails_helper'
 RSpec.describe 'Upload User Photo', type: :request do
   describe '.resolve' do
     # Running into issue passing file in the query. Upload works on Altair. 
-    xit 'happy path: uploads file and creates photo' do 
+    it 'happy path: uploads file and creates photo' do 
       user = create(:mock_user) 
-      image = file_fixture('green-blue-pink.jpeg')
+      image = Rack::Test::UploadedFile.new(file_fixture('green-blue-pink.jpeg'), "mime/type")
       query = <<~GQL
                 mutation($image: Upload!) {
                   uploadUserPhoto(input: {
-                        upload: $#{image}
+                        upload: $image
                         userId: #{user.id}}) {
                             userId
                             unsplashId
                             userUploaded
+                            url
                           }
                         } 
                  GQL
-      post '/graphql', params: { query: query }
-      result = JSON.parse(response.body, symbolize_names: true)
+      post '/graphql', params: { query: query, variables: { image: image } }
+      json = JSON.parse(response.body, symbolize_names: true)
+      photo = json[:data][:uploadUserPhoto]
+
+      expect(photo).to have_key(:userId) 
+      expect(photo).to have_key(:unsplashId)
+      expect(photo).to have_key(:userUploaded) 
+      expect(photo).to have_key(:url) 
+      
+      expect(user.photos.first.upload).to be_a(ActiveStorage::Attached::One)
+      expect(photo[:userId].to_i).to eq(user.id)
+      expect(photo[:unsplashId]).to eq(nil)
+      expect(photo[:userUploaded]).to eq(true)
+      expect(photo[:url]).to eq(nil)
     end 
 
     xit 'sad path: uploads file and creates photo' do 


### PR DESCRIPTION
## What is this change?
- Adds Happy Path and Sad Path tests to UploadUserPhoto mutation

## What does it fix?
- Incomplete `upload_user_photo` branch tests 
- Uploads files properly for testing 

## Is this a bug fix or a feature? Does it break any existing functionality or force me to update to a new version?
Bug Fix 

## How has it been tested?
Green all RSpec test