### PR TITLE
Update credentials for AWS

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
-  config.active_storage.service = :amazon
+  config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -9,8 +9,8 @@ local:
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 amazon:
   service: S3
-  access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
-  secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
+  access_key_id: ENV['AWS_ACCESS_KEY_ID'] %>
+  secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'] %>
   region: us-east-2
   bucket: on-tea-way-bucket
 


### PR DESCRIPTION
## What is this change?
- Update credential configuration for Heroku deployment

## What does it fix?
- Should update how credentials are accessed when production env is deployed

## Is this a bug fix or a feature? Does it break any existing functionality or force me to update to a new version?
Bug Fix 

## How has it been tested?
Needs to be pushed to production to be tested 